### PR TITLE
Add classroom filtering

### DIFF
--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -33,9 +33,9 @@ class Course {
   /// Returns whether this location is supported.
   bool hasClassroomLocation() => constants.classroomFilter.hasMatch(_location);
 
-  /// Returns the filtered location, according to the regex in the constants file.
+  /// Returns the uppercase filtered location, according to the regex in the constants file.
   /// The filtered location is N/A if location is null, a null string or unsupported.
   String filteredLocation() => _location != null && _location != '' && hasClassroomLocation()
-      ? constants.classroomFilter.firstMatch(_location)[0]
+      ? constants.classroomFilter.firstMatch(_location)[0].toUpperCase()
       : 'N/A';
 }

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -1,4 +1,5 @@
 import 'package:device_calendar/device_calendar.dart';
+import 'package:concordia_navigation/storage/app_constants.dart' as constants;
 
 /// This class models a course provided by Google Calendar.
 class Course {
@@ -28,4 +29,13 @@ class Course {
         _start = event.start,
         _end = event.end,
         _location = event.location;
+
+  /// Returns whether this location is supported.
+  bool hasClassroomLocation() => constants.classroomFilter.hasMatch(_location);
+
+  /// Returns the filtered location, according to the regex in the constants file.
+  /// The filtered location is N/A if location is null, a null string or unsupported.
+  String filteredLocation() => _location != null && _location != '' && hasClassroomLocation()
+      ? constants.classroomFilter.firstMatch(_location)[0]
+      : 'N/A';
 }

--- a/lib/storage/app_constants.dart
+++ b/lib/storage/app_constants.dart
@@ -27,5 +27,6 @@ const Color maroonColor = Color(0xAD0000);
 
 final RegExp calFilter = RegExp("conco|school|uni|test");
 final RegExp eventFilter = RegExp(r"[A-Z]{4}[-|\s]?\d{3}");
+final RegExp classroomFilter = RegExp(r"(H\d{3}|MBS?[1-9]\.[0-9]{3}|FG\ B-?0[3-8]0)", caseSensitive: false);
 
 final Duration dateLookahead = Duration(days: 31);

--- a/lib/widgets/weekday.dart
+++ b/lib/widgets/weekday.dart
@@ -45,18 +45,12 @@ class Weekday extends StatelessWidget {
               "${formatter.format(course?.start?.toLocal())} - ${formatter.format(course?.end?.toLocal())}",
               style: TextStyle(color: constants.blueColor),
             ),
-            Text((course == null ||
-                    course?.location == null ||
-                    course?.location == '')
-                ? "N/A"
-                : course.location),
+            Text(course.filteredLocation()),
           ],
         ),
         trailing: Row(mainAxisSize: MainAxisSize.min, children: <Widget>[
           RaisedButton(
-              onPressed: (course != null &&
-                      course?.location != '' &&
-                      course?.location != null)
+              onPressed: (course.filteredLocation() != 'N/A')
                   ? () {
                       String letter = course.location[0];
                       if (letter == "H") {


### PR DESCRIPTION
# Description
This pull request adds classroom filtering to events in the schedule screen.

If a location is either null, a null string or unsupported, the directions button will be disabled and the location will be N/A.

Locations are formatted to be uppercase to make it easier for setting destinations.

![image](https://user-images.githubusercontent.com/17802877/77858932-8d8c2980-71d4-11ea-84db-3f5422ee93e6.png)

NOTE: We may want to still display locations in the future for users' convenience.

## Related Issues
Fixes #136 