### PR TITLE
Improve next class + Refactor school week + Disable map tool bar

### DIFF
--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -26,10 +26,11 @@ class Schedule {
   /// return a list of future classes starting from now until X days into the future
   List<Course> nextClasses({days: 7}) {
     DateTime now = DateTime.now();
-    return _courses.where(
-      (course) => course.start.isAfter(now)
-          && course.end.isBefore(now.add(Duration(days: days)))
-    )?.toList();
+    return _courses
+        .where((course) =>
+            course.start.isAfter(now) &&
+            course.end.isBefore(now.add(Duration(days: days))))
+        ?.toList();
   }
 
   /// This returns a list w/ index from 0-4 representing the course on that day of the week.
@@ -45,25 +46,31 @@ class Schedule {
 
   /// returns true if [Schedule.isoWeekNumber(when)] is the same when called with now().
   ///
-  /// Weeks start on Monday and end on Sunday.
+  /// Weeks start on Saturday and end on Friday.
   ///
-  /// A course on Monday, March 23 2020 is not in the same week
-  /// as a course on Sunday, March 22 2020.
-  bool _isThisWeek(DateTime when) =>
-      _isoWeekNumber(DateTime.now()) == _isoWeekNumber(when);
+  /// A course on Friday, March 27 2020 is not in the same week
+  /// as a course on Saturday, March 28 2020.
+  bool _isThisWeek(DateTime when) {
+    DateTime now = DateTime.now();
 
-  /// https://stackoverflow.com/a/59693145/12964166
-  int _isoWeekNumber(DateTime date) {
-    int daysToAdd = DateTime.thursday - date.weekday;
-    DateTime thursdayDate = daysToAdd > 0
-        ? date.add(Duration(days: daysToAdd))
-        : date.subtract(Duration(days: daysToAdd.abs()));
-    int dayOfYearThursday = _dayOfYear(thursdayDate);
-    return 1 + ((dayOfYearThursday - 1) / 7).floor();
-  }
+    DateTime lastSaturday = now;
+    DateTime nextFriday = now;
+    int diff = now.weekday;
 
-  /// https://stackoverflow.com/a/59693145/12964166
-  int _dayOfYear(DateTime date) {
-    return date.difference(DateTime(date.year, 1, 1)).inDays;
+    if (diff < 6) {
+      diff += 7;
+    }
+
+    lastSaturday = now.subtract(Duration(days: diff % 6));
+
+    if (now.weekday < 5) {
+      nextFriday = now.add(Duration(days: 5 - now.weekday));
+    } else if (now.weekday == 6) {
+      nextFriday = now.subtract(Duration(days: 1));
+    } else {
+      nextFriday = now.add(Duration(days: 5));
+    }
+
+    return when.isAfter(lastSaturday) && when.isBefore(nextFriday);
   }
 }

--- a/lib/services/location_search.dart
+++ b/lib/services/location_search.dart
@@ -35,7 +35,7 @@ class LocationSearch extends SearchDelegate {
     CalendarData calendar = Provider.of<CalendarData>(context, listen: false);
     List<Course> nextClasses = calendar.schedule?.nextClasses(days: 7);
     if (nextClasses != null && nextClasses.isNotEmpty && nextClasses.first.filteredLocation() != "N/A") {
-      var next = nextClasses.first.filteredLocation() + " [CAL]";
+      var next = nextClasses.first.filteredLocation() + " [NEXT CLASS LOCATION]";
       // Avoid duplicates on widget rebuild
       if (!suggestionList.contains(next)) {
         suggestionList.insert(0, next);

--- a/lib/services/location_search.dart
+++ b/lib/services/location_search.dart
@@ -34,8 +34,8 @@ class LocationSearch extends SearchDelegate {
     //TODO: make it clear that the first item is from the users calendar
     CalendarData calendar = Provider.of<CalendarData>(context, listen: false);
     List<Course> nextClasses = calendar.schedule?.nextClasses(days: 7);
-    if (nextClasses != null && nextClasses.isNotEmpty) {
-      var next = nextClasses.first.location + " [CAL]";
+    if (nextClasses != null && nextClasses.isNotEmpty && nextClasses.first.filteredLocation() != "N/A") {
+      var next = nextClasses.first.filteredLocation() + " [CAL]";
       // Avoid duplicates on widget rebuild
       if (!suggestionList.contains(next)) {
         suggestionList.insert(0, next);

--- a/lib/services/location_search.dart
+++ b/lib/services/location_search.dart
@@ -35,7 +35,7 @@ class LocationSearch extends SearchDelegate {
     CalendarData calendar = Provider.of<CalendarData>(context, listen: false);
     List<Course> nextClasses = calendar.schedule?.nextClasses(days: 7);
     if (nextClasses != null && nextClasses.isNotEmpty) {
-      var next = "Next Class Location: " + nextClasses.first.location;
+      var next = nextClasses.first.location + " [CAL]";
       // Avoid duplicates on widget rebuild
       if (!suggestionList.contains(next)) {
         suggestionList.insert(0, next);

--- a/lib/storage/app_constants.dart
+++ b/lib/storage/app_constants.dart
@@ -27,6 +27,6 @@ const Color maroonColor = Color(0xAD0000);
 
 final RegExp calFilter = RegExp("conco|school|uni|test");
 final RegExp eventFilter = RegExp(r"[A-Z]{4}[-|\s]?\d{3}");
-final RegExp classroomFilter = RegExp(r"(H\d{3}|MBS?[1-9]\.[0-9]{3}|FG\ B-?0[3-8]0)", caseSensitive: false);
+final RegExp classroomFilter = RegExp(r"(H\ ?\d{3}|MB\ ?S?[1-9]\.[0-9]{3}|FG\ B-?0[3-8]0)", caseSensitive: false);
 
 final Duration dateLookahead = Duration(days: 31);

--- a/lib/widgets/map_widget.dart
+++ b/lib/widgets/map_widget.dart
@@ -134,6 +134,7 @@ class _MapWidgetState extends State<MapWidget> {
     return Stack(
       children: <Widget>[
         GoogleMap(
+            mapToolbarEnabled: false,
             myLocationEnabled: true,
             myLocationButtonEnabled: false,
             compassEnabled: false,

--- a/lib/widgets/weekday.dart
+++ b/lib/widgets/weekday.dart
@@ -52,7 +52,7 @@ class Weekday extends StatelessWidget {
           RaisedButton(
               onPressed: (course.filteredLocation() != 'N/A')
                   ? () {
-                      String letter = course.location[0];
+                      String letter = course.filteredLocation()[0];
                       if (letter == "H") {
                         Provider.of<MapData>(context, listen: false)
                             .changeCampus('sgw');


### PR DESCRIPTION
# Description
This changes the definition of classes for the current week, meaning users won't see their courses for the past week if it's a Saturday; they'll see those for the coming week.

The map tool bar setting was disabled since it interferes with some of the buttons on our interface.

Finally, the search bar for locations was improved by implementing filtering, similarly to what is done on the course schedule screen.

## Related Issues
#137 