### PR TITLE
Fixes saturday events + adds unit test

### DIFF
--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -50,8 +50,8 @@ class Schedule {
   ///
   /// A course on Friday, March 27 2020 is not in the same week
   /// as a course on Saturday, March 28 2020.
-  bool _isThisWeek(DateTime when) {
-    DateTime now = DateTime.now();
+  static bool _isThisWeek(DateTime when, [DateTime now]) {
+    now = now ?? DateTime.now();
 
     DateTime lastSaturday = now;
     DateTime nextFriday = now;

--- a/lib/models/schedule.dart
+++ b/lib/models/schedule.dart
@@ -1,5 +1,6 @@
 import 'package:concordia_navigation/models/course.dart';
 import 'package:device_calendar/device_calendar.dart';
+import 'package:meta/meta.dart' show visibleForTesting;
 
 class Schedule {
   List<Course> _courses;
@@ -44,6 +45,10 @@ class Schedule {
           (course) => course.start.weekday == day && _isThisWeek(course.start))
       .toList();
 
+  @visibleForTesting
+  static bool isThisWeek(DateTime when, DateTime now) =>
+      Schedule._isThisWeek(when, now);
+
   /// returns true if [Schedule.isoWeekNumber(when)] is the same when called with now().
   ///
   /// Weeks start on Saturday and end on Friday.
@@ -55,25 +60,22 @@ class Schedule {
 
     DateTime lastSaturday = now;
     DateTime nextFriday = now;
-    int diff = now.weekday;
-
-    if (diff < 6) {
-      diff += 7;
-    }
-
-    lastSaturday = now.subtract(Duration(days: diff % 6));
 
     if (now.weekday < 5) {
       nextFriday = now.add(Duration(days: 5 - now.weekday));
+      lastSaturday = now.subtract(Duration(days: now.weekday + 1));
+    } else if (now.weekday == 5) {
+      lastSaturday = now.subtract(Duration(days: now.weekday + 1));
     } else if (now.weekday == 6) {
-      nextFriday = now.subtract(Duration(days: 1));
-    } else {
+      nextFriday = now.add(Duration(days: 6));
+    } else if (now.weekday == 7) {
+      lastSaturday = now.subtract(Duration(days: 1));
       nextFriday = now.add(Duration(days: 5));
     }
 
     // Set time of next friday to 1ms before midnight
-    nextFriday =
-        DateTime(nextFriday.year, nextFriday.month, nextFriday.day, 23, 59, 59, 59);
+    nextFriday = DateTime(
+        nextFriday.year, nextFriday.month, nextFriday.day, 23, 59, 59, 59);
 
     // Set time of last saturday to midnight
     lastSaturday = DateTime(

--- a/lib/services/shuttle_service.dart
+++ b/lib/services/shuttle_service.dart
@@ -11,7 +11,7 @@ class ShuttleService {
 
   static String getNextShuttle(campus, [DateTime time]) {
     time = time ?? DateTime.now();
-    if (time.weekday == 7 || time.weekday == 6) {
+    if (time.weekday == 7 || time.weekday == 6 || campus == null) {
       return null;
     } else {
       var length = time.weekday == 5

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,42 +21,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: "direct main"
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   csslib:
     dependency: transitive
     description:
@@ -221,14 +221,14 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   intl:
     dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0"
+    version: "0.16.1"
   intl_translation:
     dependency: "direct main"
     description:
@@ -445,14 +445,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.4"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
@@ -499,7 +499,7 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "2.0.0"
   source_maps:
     dependency: transitive
     description:
@@ -513,7 +513,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -535,6 +535,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -548,21 +555,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.4"
+    version: "1.14.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.3"
   typed_data:
     dependency: transitive
     description:
@@ -605,13 +612,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0+1"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
   yaml:
     dependency: transitive
     description:

--- a/test/models/schedule_test.dart
+++ b/test/models/schedule_test.dart
@@ -1,0 +1,44 @@
+import 'package:concordia_navigation/models/schedule.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+      DateTime event;
+      DateTime current; 
+  group('Schedule', () {
+    test('returns false if it is saturday and event is friday', () {
+      // saturday 8:00AM - beginning of new school week
+      current = DateTime(2020, 4, 4, 8);
+      
+      // friday 8:00AM - end of last school week
+      event = DateTime(2020, 4, 3, 8);
+      
+      expect(Schedule.isThisWeek(event, current), false);
+    });
+
+    test('returns false if it is friday and event is saturday', () {
+      // saturday 8:00AM - beginning of new school week
+      event = DateTime(2020, 4, 4, 5);
+      
+      // friday 8:00AM - end of last school week
+      current = DateTime(2020, 4, 3, 5);
+      
+      expect(Schedule.isThisWeek(event, current), false);
+    });
+
+    test('returns false if it is friday at 11:59 and event is friday', () {
+      // thursday 12:01AM - beginning of new school week
+      event = DateTime(2020, 4, 2, 0, 1);
+      
+      // friday 23:59PM - end of last school week
+      current = DateTime(2020, 4, 3, 23, 59);
+      
+      expect(Schedule.isThisWeek(event, current), true);
+    });
+
+    test('returns true if event is now', () {
+      current = DateTime.now();
+      
+      expect(Schedule.isThisWeek(current, null), true);
+    });
+  });
+}


### PR DESCRIPTION
## Description

This pull request fixes a bug where events weren't shown if the current time is a Saturday.

Additionally, it makes `Schedule._isThisWeek()` static and adds an optional DateTime parameter for the current time. This is done for testing purposes.

A unit test for `Schedule._isThisWeek()` is also added.


## Related Issues
Fixes #163