### PR TITLE
prompt user to enable location services when off

### DIFF
--- a/lib/providers/map_data.dart
+++ b/lib/providers/map_data.dart
@@ -99,7 +99,7 @@ class MapData extends ChangeNotifier {
 
   CameraPosition getFixedLocationCamera() {
     return CameraPosition(
-        target: constants.sgw,
+        target: locationService.current?.toLatLng() ?? constants.sgw,
         zoom: 16.5,
         tilt: 30.440717697143555,
         bearing: 30.8334901395799,

--- a/lib/services/outdoor/location_service.dart
+++ b/lib/services/outdoor/location_service.dart
@@ -57,11 +57,27 @@ class LocationService {
     return true;
   }
 
+  /// Checks that location service is enabled
+  Future<bool> checkService() async {
+    bool service = await _location.serviceEnabled();
+    if (service != true) {
+      service = await _location.requestService();
+      if (service != true) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// Clean wrapper for performing privileged actions
   void withPermission(void method()) {
     checkPermission().then((granted) => {
       if(granted == true) {
-        method()
+        checkService().then((service) => {
+          if(service == true) {
+            method()
+          }
+        })
       }
     });
   }


### PR DESCRIPTION
## Description

Ensures the user doesn't have to completely close the app and relaunch it if they started without location services enabled. Prompts user to enable location on launch and on tap of location button if the phone's location services are currently disabled.

## Related Issues

#121 #181
